### PR TITLE
Added extra domain for myiptest.com

### DIFF
--- a/filterlist
+++ b/filterlist
@@ -117,6 +117,7 @@
 #Main: myiptest.com
 ||myiptest.com^important,all
 ||myiptest.com/img.php^$important,all
+||myiptest.com/staticpages/index.php/how-about-you^$important,all
 
 ###########################
 # Unsorted #


### PR DESCRIPTION
For some reason the myiptest.com/ never blocked the rest of the domain, so added the actual domain to do so.